### PR TITLE
*-linux-macos.sh: Improve formatting and adjust

### DIFF
--- a/chimera1n-deploy-linux-macos.sh
+++ b/chimera1n-deploy-linux-macos.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-if [ $(uname) = "Darwin" ]; then
-	if [ $(uname -p) = "arm" ] || [ $(uname -p) = "arm64" ]; then
+if [ "$(uname)" = "Darwin" ]; then
+	if [ "$(uname -p)" = "arm" ] || [ "$(uname -p)" = "arm64" ]; then
 		echo "It's recommended this script be ran on macOS/Linux with a clean iOS device running checkra1n attached unless migrating from older bootstrap."
 		read -p "Press enter to continue"
 		ARM=yes
+		if [[ "${USER}" != root ]]; then
+			echo "Default password is: alpine"
+			su root || { echo "Must be Root, exiting"; exit 1; }
+		fi
+		cd /var/root || { echo "Unable to change directory, exiting"; exit 1; }
 	fi
 fi
 
@@ -32,71 +37,73 @@ else
 		echo "Error: iproxy not found"
 		exit 1
 	fi
+	TMP="$(mktemp -d 2>/dev/null || { rm -rf odyssey-tmp; mkdir odyssey-tmp; })"
+	cd "${TMP:-odyssey-tmp}" || { echo "Unable to change directory, exiting"; exit 1; }
 fi
-rm -rf odyssey-tmp
-mkdir odyssey-tmp
-cd odyssey-tmp
 
-echo '#!/bin/zsh' > odyssey-device-deploy.sh
-if [[ ! "${ARM}" = yes ]]; then
-	echo 'cd /var/root' >> odyssey-device-deploy.sh
+cat <<'EOF' > odyssey-device-deploy.sh
+#!/bin/zsh
+if [[ "${USER}" != root ]]; then
+	echo "Default password is: alpine"
+	su root || { echo "Must be Root, exiting"; exit 1; }
 fi
-echo 'if [[ -f "/.bootstrapped" ]]; then' >> odyssey-device-deploy.sh
-echo 'mkdir -p /odyssey && mv migration /odyssey' >> odyssey-device-deploy.sh
-echo 'chmod 0755 /odyssey/migration' >> odyssey-device-deploy.sh
-echo '/odyssey/migration' >> odyssey-device-deploy.sh
-echo 'rm -rf /odyssey' >> odyssey-device-deploy.sh
-echo 'else' >> odyssey-device-deploy.sh
-echo 'VER=$(/binpack/usr/bin/plutil -key ProductVersion /System/Library/CoreServices/SystemVersion.plist)' >> odyssey-device-deploy.sh
-echo 'if [[ "${VER%.*}" -ge 12 ]] && [[ "${VER%.*}" -lt 13 ]]; then' >> odyssey-device-deploy.sh
-echo 'CFVER=1500' >> odyssey-device-deploy.sh
-echo 'elif [[ "${VER%.*}" -ge 13 ]]; then' >> odyssey-device-deploy.sh
-echo 'CFVER=1600' >> odyssey-device-deploy.sh
-echo 'else' >> odyssey-device-deploy.sh
-echo 'echo "${VER} not compatible."' >> odyssey-device-deploy.sh
-echo 'exit 1' >> odyssey-device-deploy.sh
-echo 'fi' >> odyssey-device-deploy.sh
-echo 'gzip -d bootstrap_${CFVER}-ssh.tar.gz' >> odyssey-device-deploy.sh
-echo 'mount -uw -o union /dev/disk0s1s1' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/profile' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/profile.d' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/alternatives' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/apt' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/ssl' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/ssh' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/dpkg' >> odyssey-device-deploy.sh
-echo 'rm -rf /Library/dpkg' >> odyssey-device-deploy.sh
-echo 'rm -rf /var/cache' >> odyssey-device-deploy.sh
-echo 'rm -rf /var/lib' >> odyssey-device-deploy.sh
-echo 'tar --preserve-permissions -xkf bootstrap_${CFVER}-ssh.tar -C /' >> odyssey-device-deploy.sh
-echo '/Library/dpkg/info/openssh.postinst || true' >> odyssey-device-deploy.sh
-echo 'launchctl load -w /Library/LaunchDaemons/com.openssh.sshd.plist || true' >> odyssey-device-deploy.sh
-printf %s 'SNAPSHOT=$(snappy -s | ' >> odyssey-device-deploy.sh
-printf %s "cut -d ' ' -f 3 | tr -d '\n')" >> odyssey-device-deploy.sh
-echo '' >> odyssey-device-deploy.sh
-echo 'snappy -f / -r $SNAPSHOT -t orig-fs' >> odyssey-device-deploy.sh
-echo 'fi' >> odyssey-device-deploy.sh
-echo '/usr/libexec/firmware' >> odyssey-device-deploy.sh
-echo 'mkdir -p /etc/apt/sources.list.d/' >> odyssey-device-deploy.sh
-echo 'echo "Types: deb" > /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "URIs: https://repo.theodyssey.dev/" >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "Suites: ./" >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "Components: " >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "" >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'mkdir -p /etc/apt/preferenced.d/' >> odyssey-device-deploy.sh
-echo 'echo "Package: *" > /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'echo "Pin: release n=odyssey-ios" >> /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'echo "Pin-Priority: 1001" >> /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'echo "" >> /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/X11:/usr/games dpkg -i org.coolstar.sileo_1.8.1_iphoneos-arm.deb' >> odyssey-device-deploy.sh
-echo 'uicache -p /Applications/Sileo.app' >> odyssey-device-deploy.sh
-echo 'echo -n "" > /var/lib/dpkg/available' >> odyssey-device-deploy.sh
-echo '/Library/dpkg/info/profile.d.postinst' >> odyssey-device-deploy.sh
-echo 'touch /.mount_rw' >> odyssey-device-deploy.sh
-echo 'touch /.installed_odyssey' >> odyssey-device-deploy.sh
-echo 'rm bootstrap*.tar*' >> odyssey-device-deploy.sh
-echo 'rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb' >> odyssey-device-deploy.sh
-echo 'rm odyssey-device-deploy.sh' >> odyssey-device-deploy.sh
+cd /var/root || { echo "Unable to change directory, exiting"; exit 1; }
+if [[ -f "/.bootstrapped" ]]; then
+	mkdir -p /odyssey && mv migration /odyssey
+	chmod 0755 /odyssey/migration
+	/odyssey/migration
+	rm -rf /odyssey
+else
+	VER=$(/binpack/usr/bin/plutil -key ProductVersion /System/Library/CoreServices/SystemVersion.plist)
+	if [[ "${VER%.*}" -ge 12 ]] && [[ "${VER%.*}" -lt 13 ]]; then
+		CFVER=1500
+	elif [[ "${VER%.*}" -ge 13 ]]; then
+		CFVER=1600
+	else
+		echo "${VER} not compatible."
+		exit 1
+	fi
+	gzip -d bootstrap_${CFVER}-ssh.tar.gz
+	mount -uw -o union /dev/disk0s1s1
+	rm -rf /etc/profile
+	rm -rf /etc/profile.d
+	rm -rf /etc/alternatives
+	rm -rf /etc/apt
+	rm -rf /etc/ssl
+	rm -rf /etc/ssh
+	rm -rf /etc/dpkg
+	rm -rf /Library/dpkg
+	rm -rf /var/cache
+	rm -rf /var/lib
+	tar --preserve-permissions -xkf bootstrap_${CFVER}-ssh.tar -C /
+	/Library/dpkg/info/openssh.postinst || true
+	launchctl load -w /Library/LaunchDaemons/com.openssh.sshd.plist || true
+	SNAPSHOT=$(snappy -s | cut -d " " -f 3 | tr -d '\n')
+	snappy -f / -r $SNAPSHOT -t orig-fs
+fi
+/usr/libexec/firmware
+mkdir -p /etc/apt/sources.list.d/
+echo "Types: deb" > /etc/apt/sources.list.d/odyssey.sources
+echo "URIs: https://repo.theodyssey.dev/" >> /etc/apt/sources.list.d/odyssey.sources
+echo "Suites: ./" >> /etc/apt/sources.list.d/odyssey.sources
+echo "Components: " >> /etc/apt/sources.list.d/odyssey.sources
+echo "" >> /etc/apt/sources.list.d/odyssey.sources
+mkdir -p /etc/apt/preferenced.d/
+echo "Package: *" > /etc/apt/preferenced.d/odyssey
+echo "Pin: release n=odyssey-ios" >> /etc/apt/preferenced.d/odyssey
+echo "Pin-Priority: 1001" >> /etc/apt/preferenced.d/odyssey
+echo "" >> /etc/apt/preferenced.d/odyssey
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/X11:/usr/games dpkg -i org.coolstar.sileo_1.8.1_iphoneos-arm.deb
+uicache -p /Applications/Sileo.app
+echo -n "" > /var/lib/dpkg/available
+/Library/dpkg/info/profile.d.postinst
+touch /.mount_rw
+touch /.installed_odyssey
+rm bootstrap*.tar*
+rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb
+rm odyssey-device-deploy.sh
+rm migration 2>/dev/null
+EOF
 
 echo "Downloading Resources..."
 curl -L -O https://github.com/coolstar/odyssey-bootstrap/raw/master/bootstrap_1500-ssh.tar.gz -O https://github.com/coolstar/odyssey-bootstrap/raw/master/bootstrap_1600-ssh.tar.gz -O https://github.com/coolstar/odyssey-bootstrap/raw/master/migration -O https://github.com/coolstar/odyssey-bootstrap/raw/master/org.coolstar.sileo_1.8.1_iphoneos-arm.deb

--- a/chimera1n-deploy-linux-macos.sh
+++ b/chimera1n-deploy-linux-macos.sh
@@ -103,8 +103,8 @@ rm bootstrap*.tar*
 rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb
 rm odyssey-device-deploy.sh
 rm migration 2>/dev/null
-apt update
-apt install org.coolstar.libhooker || echo "Unable to install libhooker. Open Sileo and do so manually"
+apt-get update
+apt-get install org.coolstar.libhooker || echo "Unable to install libhooker. Open Sileo and do so manually"
 EOF
 
 echo "Downloading Resources..."

--- a/chimera1n-deploy-linux-macos.sh
+++ b/chimera1n-deploy-linux-macos.sh
@@ -103,6 +103,8 @@ rm bootstrap*.tar*
 rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb
 rm odyssey-device-deploy.sh
 rm migration 2>/dev/null
+apt update
+apt install org.coolstar.libhooker || echo "Unable to install libhooker. Open Sileo and do so manually"
 EOF
 
 echo "Downloading Resources..."

--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
-if [ $(uname) = "Darwin" ]; then
-	if [ $(uname -p) = "arm" ] || [ $(uname -p) = "arm64" ]; then
+if [ "$(uname)" = "Darwin" ]; then
+	if [ "$(uname -p)" = "arm" ] || [ "$(uname -p)" = "arm64" ]; then
 		echo "It's recommended this script be ran on macOS/Linux with a clean iOS device running checkra1n attached unless migrating from older bootstrap."
 		read -p "Press enter to continue"
 		ARM=yes
+		if [[ "${USER}" != root ]]; then
+			echo "Default password is: alpine"
+			su root || { echo "Must be Root, exiting"; exit 1; }
+		fi
+		cd /var/root || { echo "Unable to change directory, exiting"; exit 1; }
 	fi
 fi
 
@@ -32,71 +37,73 @@ else
 		echo "Error: iproxy not found"
 		exit 1
 	fi
+	TMP="$(mktemp -d 2>/dev/null || { rm -rf odyssey-tmp; mkdir odyssey-tmp; })"
+	cd "${TMP:-odyssey-tmp}" || { echo "Unable to change directory, exiting"; exit 1; }
 fi
-rm -rf odyssey-tmp
-mkdir odyssey-tmp
-cd odyssey-tmp
 
-echo '#!/bin/zsh' > odyssey-device-deploy.sh
-if [[ ! "${ARM}" = yes ]]; then
-	echo 'cd /var/root' >> odyssey-device-deploy.sh
+cat <<'EOF' > odyssey-device-deploy.sh
+#!/bin/zsh
+if [[ "${USER}" != root ]]; then
+	echo "Default password is: alpine"
+	su root || { echo "Must be Root, exiting"; exit 1; }
 fi
-echo 'if [[ -f "/.bootstrapped" ]]; then' >> odyssey-device-deploy.sh
-echo 'mkdir -p /odyssey && mv migration /odyssey' >> odyssey-device-deploy.sh
-echo 'chmod 0755 /odyssey/migration' >> odyssey-device-deploy.sh
-echo '/odyssey/migration' >> odyssey-device-deploy.sh
-echo 'rm -rf /odyssey' >> odyssey-device-deploy.sh
-echo 'else' >> odyssey-device-deploy.sh
-echo 'VER=$(/binpack/usr/bin/plutil -key ProductVersion /System/Library/CoreServices/SystemVersion.plist)' >> odyssey-device-deploy.sh
-echo 'if [[ "${VER%.*}" -ge 12 ]] && [[ "${VER%.*}" -lt 13 ]]; then' >> odyssey-device-deploy.sh
-echo 'CFVER=1500' >> odyssey-device-deploy.sh
-echo 'elif [[ "${VER%.*}" -ge 13 ]]; then' >> odyssey-device-deploy.sh
-echo 'CFVER=1600' >> odyssey-device-deploy.sh
-echo 'else' >> odyssey-device-deploy.sh
-echo 'echo "${VER} not compatible."' >> odyssey-device-deploy.sh
-echo 'exit 1' >> odyssey-device-deploy.sh
-echo 'fi' >> odyssey-device-deploy.sh
-echo 'gzip -d bootstrap_${CFVER}-ssh.tar.gz' >> odyssey-device-deploy.sh
-echo 'mount -uw -o union /dev/disk0s1s1' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/profile' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/profile.d' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/alternatives' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/apt' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/ssl' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/ssh' >> odyssey-device-deploy.sh
-echo 'rm -rf /etc/dpkg' >> odyssey-device-deploy.sh
-echo 'rm -rf /Library/dpkg' >> odyssey-device-deploy.sh
-echo 'rm -rf /var/cache' >> odyssey-device-deploy.sh
-echo 'rm -rf /var/lib' >> odyssey-device-deploy.sh
-echo 'tar --preserve-permissions -xkf bootstrap_${CFVER}-ssh.tar -C /' >> odyssey-device-deploy.sh
-echo '/Library/dpkg/info/openssh.postinst || true' >> odyssey-device-deploy.sh
-echo 'launchctl load -w /Library/LaunchDaemons/com.openssh.sshd.plist || true' >> odyssey-device-deploy.sh
-printf %s 'SNAPSHOT=$(snappy -s | ' >> odyssey-device-deploy.sh
-printf %s "cut -d ' ' -f 3 | tr -d '\n')" >> odyssey-device-deploy.sh
-echo '' >> odyssey-device-deploy.sh
-echo 'snappy -f / -r $SNAPSHOT -t orig-fs' >> odyssey-device-deploy.sh
-echo 'fi' >> odyssey-device-deploy.sh
-echo '/usr/libexec/firmware' >> odyssey-device-deploy.sh
-echo 'mkdir -p /etc/apt/sources.list.d/' >> odyssey-device-deploy.sh
-echo 'echo "Types: deb" > /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "URIs: https://repo.theodyssey.dev/" >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "Suites: ./" >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "Components: " >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'echo "" >> /etc/apt/sources.list.d/odyssey.sources' >> odyssey-device-deploy.sh
-echo 'mkdir -p /etc/apt/preferenced.d/' >> odyssey-device-deploy.sh
-echo 'echo "Package: *" > /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'echo "Pin: release n=odyssey-ios" >> /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'echo "Pin-Priority: 1001" >> /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'echo "" >> /etc/apt/preferenced.d/odyssey' >> odyssey-device-deploy.sh
-echo 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/X11:/usr/games dpkg -i org.coolstar.sileo_1.8.1_iphoneos-arm.deb' >> odyssey-device-deploy.sh
-echo 'uicache -p /Applications/Sileo.app' >> odyssey-device-deploy.sh
-echo 'echo -n "" > /var/lib/dpkg/available' >> odyssey-device-deploy.sh
-echo '/Library/dpkg/info/profile.d.postinst' >> odyssey-device-deploy.sh
-echo 'touch /.mount_rw' >> odyssey-device-deploy.sh
-echo 'touch /.installed_odyssey' >> odyssey-device-deploy.sh
-echo 'rm bootstrap*.tar*' >> odyssey-device-deploy.sh
-echo 'rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb' >> odyssey-device-deploy.sh
-echo 'rm odyssey-device-deploy.sh' >> odyssey-device-deploy.sh
+cd /var/root || { echo "Unable to change directory, exiting"; exit 1; }
+if [[ -f "/.bootstrapped" ]]; then
+	mkdir -p /odyssey && mv migration /odyssey
+	chmod 0755 /odyssey/migration
+	/odyssey/migration
+	rm -rf /odyssey
+else
+	VER=$(/binpack/usr/bin/plutil -key ProductVersion /System/Library/CoreServices/SystemVersion.plist)
+	if [[ "${VER%.*}" -ge 12 ]] && [[ "${VER%.*}" -lt 13 ]]; then
+		CFVER=1500
+	elif [[ "${VER%.*}" -ge 13 ]]; then
+		CFVER=1600
+	else
+		echo "${VER} not compatible."
+		exit 1
+	fi
+	gzip -d bootstrap_${CFVER}-ssh.tar.gz
+	mount -uw -o union /dev/disk0s1s1
+	rm -rf /etc/profile
+	rm -rf /etc/profile.d
+	rm -rf /etc/alternatives
+	rm -rf /etc/apt
+	rm -rf /etc/ssl
+	rm -rf /etc/ssh
+	rm -rf /etc/dpkg
+	rm -rf /Library/dpkg
+	rm -rf /var/cache
+	rm -rf /var/lib
+	tar --preserve-permissions -xkf bootstrap_${CFVER}-ssh.tar -C /
+	/Library/dpkg/info/openssh.postinst || true
+	launchctl load -w /Library/LaunchDaemons/com.openssh.sshd.plist || true
+	SNAPSHOT=$(snappy -s | cut -d " " -f 3 | tr -d '\n')
+	snappy -f / -r $SNAPSHOT -t orig-fs
+fi
+/usr/libexec/firmware
+mkdir -p /etc/apt/sources.list.d/
+echo "Types: deb" > /etc/apt/sources.list.d/odyssey.sources
+echo "URIs: https://repo.theodyssey.dev/" >> /etc/apt/sources.list.d/odyssey.sources
+echo "Suites: ./" >> /etc/apt/sources.list.d/odyssey.sources
+echo "Components: " >> /etc/apt/sources.list.d/odyssey.sources
+echo "" >> /etc/apt/sources.list.d/odyssey.sources
+mkdir -p /etc/apt/preferenced.d/
+echo "Package: *" > /etc/apt/preferenced.d/odyssey
+echo "Pin: release n=odyssey-ios" >> /etc/apt/preferenced.d/odyssey
+echo "Pin-Priority: 1001" >> /etc/apt/preferenced.d/odyssey
+echo "" >> /etc/apt/preferenced.d/odyssey
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/X11:/usr/games dpkg -i org.coolstar.sileo_1.8.1_iphoneos-arm.deb
+uicache -p /Applications/Sileo.app
+echo -n "" > /var/lib/dpkg/available
+/Library/dpkg/info/profile.d.postinst
+touch /.mount_rw
+touch /.installed_odyssey
+rm bootstrap*.tar*
+rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb
+rm odyssey-device-deploy.sh
+rm migration 2>/dev/null
+EOF
 
 echo "Downloading Resources..."
 curl -L -O https://github.com/coolstar/odyssey-bootstrap/raw/master/bootstrap_1500-ssh.tar.gz -O https://github.com/coolstar/odyssey-bootstrap/raw/master/bootstrap_1600-ssh.tar.gz -O https://github.com/coolstar/odyssey-bootstrap/raw/master/migration -O https://github.com/coolstar/odyssey-bootstrap/raw/master/org.coolstar.sileo_1.8.1_iphoneos-arm.deb

--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -103,8 +103,8 @@ rm bootstrap*.tar*
 rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb
 rm odyssey-device-deploy.sh
 rm migration 2>/dev/null
-apt update
-apt install org.coolstar.libhooker || echo "Unable to install libhooker. Open Sileo and do so manually"
+apt-get update
+apt-get install org.coolstar.libhooker || echo "Unable to install libhooker. Open Sileo and do so manually"
 EOF
 
 echo "Downloading Resources..."

--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -103,6 +103,8 @@ rm bootstrap*.tar*
 rm org.coolstar.sileo_1.8.1_iphoneos-arm.deb
 rm odyssey-device-deploy.sh
 rm migration 2>/dev/null
+apt update
+apt install org.coolstar.libhooker || echo "Unable to install libhooker. Open Sileo and do so manually"
 EOF
 
 echo "Downloading Resources..."


### PR DESCRIPTION
This pr does the following:
- If running on the device itself, make sure you are root and are in the correct directory
- Use `mktemp` if available otherwise fallback to creating odyssey-tmp directory.
- Improve the readability of odyssey-device-deploy.sh script.
- Remove `migration` binary after odyssey-device-deploy.sh runs as it isn't currently being cleaned up unless a previous bootstrap was detected.
- Add a second root and dir check into odyssey-device-deploy.sh script