### PR TITLE
Use pkill if killall doesn't exist

### DIFF
--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -114,5 +114,10 @@ else
 	echo "Default password is: alpine"
 	ssh -p4444 -o "StrictHostKeyChecking no" -o "UserKnownHostsFile=/dev/null" root@127.0.0.1 "zsh /var/root/odyssey-device-deploy.sh"
 	echo "All Done!"
-	killall iproxy
+	if ! command -v killall &> /dev/null
+	then
+		pkill -x iproxy
+	else
+		killall iproxy
+	fi
 fi


### PR DESCRIPTION
Turned this into an if, because for instance my phone seems to have `killall` and no `pkill`, but on the other hand a default Debian installation has only `pkill`, and to get `killall`, one needs to additionally install `psmisc`...

pkill uses -x here to match killall's default behavior
```
-x, --exact
              Only match processes whose names (or command line if -f is specified) exactly match the pattern.
```