### PR TITLE
Fix script failing if iOS version contains more than one dot

### DIFF
--- a/chimera1n-deploy-linux-macos.sh
+++ b/chimera1n-deploy-linux-macos.sh
@@ -45,11 +45,11 @@ echo '/odyssey/migration' >> odyssey-device-deploy.sh
 echo 'rm -rf /odyssey' >> odyssey-device-deploy.sh
 echo 'else' >> odyssey-device-deploy.sh
 echo 'VER=$(/binpack/usr/bin/plutil -key ProductVersion /System/Library/CoreServices/SystemVersion.plist)' >> odyssey-device-deploy.sh
-echo 'if [[ "${VER%.*}" -ge 12 ]] && [[ "${VER%.*}" -lt 13 ]]; then' >> odyssey-device-deploy.sh
+echo 'if [[ "${VER%%.*}" -ge 12 ]] && [[ "${VER%%.*}" -lt 13 ]]; then' >> odyssey-device-deploy.sh
 echo 'CFVER=1500' >> odyssey-device-deploy.sh
-echo 'elif [[ "${VER%.*}" -ge 13 ]]; then' >> odyssey-device-deploy.sh
+echo 'elif [[ "${VER%%.*}" -ge 13 ]]; then' >> odyssey-device-deploy.sh
 echo 'CFVER=1600' >> odyssey-device-deploy.sh
-echo 'elif [[ "${VER%.*}" -ge 14 ]]; then' >> odyssey-device-deploy.sh
+echo 'elif [[ "${VER%%.*}" -ge 14 ]]; then' >> odyssey-device-deploy.sh
 echo 'CFVER=1700' >> odyssey-device-deploy.sh
 echo 'else' >> odyssey-device-deploy.sh
 echo 'echo "${VER} not compatible."' >> odyssey-device-deploy.sh

--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -45,11 +45,11 @@ echo '/odyssey/migration' >> odyssey-device-deploy.sh
 echo 'rm -rf /odyssey' >> odyssey-device-deploy.sh
 echo 'else' >> odyssey-device-deploy.sh
 echo 'VER=$(/binpack/usr/bin/plutil -key ProductVersion /System/Library/CoreServices/SystemVersion.plist)' >> odyssey-device-deploy.sh
-echo 'if [[ "${VER%.*}" -ge 12 ]] && [[ "${VER%.*}" -lt 13 ]]; then' >> odyssey-device-deploy.sh
+echo 'if [[ "${VER%%.*}" -ge 12 ]] && [[ "${VER%%.*}" -lt 13 ]]; then' >> odyssey-device-deploy.sh
 echo 'CFVER=1500' >> odyssey-device-deploy.sh
-echo 'elif [[ "${VER%.*}" -ge 13 ]]; then' >> odyssey-device-deploy.sh
+echo 'elif [[ "${VER%%.*}" -ge 13 ]]; then' >> odyssey-device-deploy.sh
 echo 'CFVER=1600' >> odyssey-device-deploy.sh
-echo 'elif [[ "${VER%.*}" -ge 14 ]]; then' >> odyssey-device-deploy.sh
+echo 'elif [[ "${VER%%.*}" -ge 14 ]]; then' >> odyssey-device-deploy.sh
 echo 'CFVER=1700' >> odyssey-device-deploy.sh
 echo 'else' >> odyssey-device-deploy.sh
 echo 'echo "${VER} not compatible."' >> odyssey-device-deploy.sh


### PR DESCRIPTION
The script fails if the variable VER (so the iOS version) is equal to any number with two dots (e.g. 14.4.2) and it outputs `${VER} not compatible.`.
Unlike zsh, bash doesn't remove everything after the dot in VER on lines 48, 50 and 52. It only removes the number after the first dot and doesn't remove the number after the second dot.

This PR fixes this by changing `${VER%.*}` to `${VER%%.*}`. Now bash correctly removes everything after the first dot in VER.