### PR TITLE
temp fix for users bootstrapping their device without having a rootfs snapshot

### DIFF
--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -63,13 +63,15 @@ else
     echo "${VER} not compatible."
     exit 1
 fi
+
+SNAPSHOT=$(snappy -s | cut -d ' ' -f 3 | tr -d '\n')
+snappy -f / -r "$SNAPSHOT" -t orig-fs > /dev/null 2>&1
+
 mount -o rw,union,update /dev/disk0s1s1
 rm -rf /etc/{alternatives,apt,ssl,ssh,dpkg,profile{,.d}} /Library/dpkg /var/{cache,lib}
 gzip -d bootstrap_${CFVER}.tar.gz
 tar --preserve-permissions -xkf bootstrap_${CFVER}.tar -C /
-SNAPSHOT=$(snappy -s | cut -d ' ' -f 3 | tr -d '\n')
 
-snappy -f / -r "$SNAPSHOT" -t orig-fs > /dev/null 2>&1
 /prep_bootstrap.sh
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/X11:/usr/games
 if [[ $VER = 12.1* ]] || [[ $VER = 12.0* ]]; then


### PR DESCRIPTION
without this fix the device is first bootstrapped and then snappy creates a new snapshot instead of renaming because it can't find it. this will cause orig-fs to have procursus's bootstrap in it thus making it impossible to properly restore rootfs to stock. (this fix just moves the snappy commands to before disk0s1s1 is mounted r/w) i don't really know snappy's syntax so that's why i didn't actually fix it, that might come another time if i can get my hands on a snapshotless unbootstrapped checkra1n device to test things