### PR TITLE
which to command -v

### DIFF
--- a/procursus-deploy-linux-macos.sh
+++ b/procursus-deploy-linux-macos.sh
@@ -24,12 +24,12 @@ Press enter to continue.
 EOF
 read -r REPLY
 
-if ! which curl > /dev/null; then
+if ! command -v curl > /dev/null; then
 	echo "Error: cURL not found."
 	exit 1
 fi
 if [ "${ARM}" != yes ]; then
-	if ! which iproxy > /dev/null; then
+	if ! command -v iproxy > /dev/null; then
 		echo "Error: iproxy not found."
 		exit 1
 	fi


### PR DESCRIPTION
This PR changes ``which`` to ``command -v`` to remove the ``/usr/bin/which: this version of `which' is deprecated; use `command -v' in scripts instead.`` warning message that appears on some linux distributions.